### PR TITLE
slightly reorder wall layout

### DIFF
--- a/app/src/main/java/com/example/wspinapp/AddRouteActivity.kt
+++ b/app/src/main/java/com/example/wspinapp/AddRouteActivity.kt
@@ -104,7 +104,7 @@ class AddHoldsOverlayView constructor(context: Context, attrs: AttributeSet?) : 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         if (frame == null) { // dirty hack this should be done in slightly different way
-            frame = ViewFrame(0f, 0f, this.width.toFloat(), this.height.toFloat(), 1f)
+            frame = ViewFrame(0f, 0f, this.width.toFloat(), this.height.toFloat(), 1f, this.measuredWidth, this.measuredHeight)
         }
         holdPicker.onDraw(canvas, frame!!)
 

--- a/app/src/main/java/com/example/wspinapp/model/Schema.kt
+++ b/app/src/main/java/com/example/wspinapp/model/Schema.kt
@@ -8,6 +8,10 @@ import kotlinx.parcelize.Parcelize
 @Serializable
 @Parcelize
 data class Hold(
+//    Assume every image is in ratio 3:4
+//    X should be a Float between 0 - 100
+//    Y as well
+//
     val X: Float,
     val Y: Float,
     val Size: Float,

--- a/app/src/main/java/com/example/wspinapp/model/Schema.kt
+++ b/app/src/main/java/com/example/wspinapp/model/Schema.kt
@@ -1,6 +1,8 @@
 package com.example.wspinapp.model
 
 import android.os.Parcelable
+import android.view.View
+import com.example.wspinapp.utils.ViewFrame
 import kotlinx.serialization.Serializable
 import kotlinx.parcelize.Parcelize
 
@@ -8,13 +10,9 @@ import kotlinx.parcelize.Parcelize
 @Serializable
 @Parcelize
 data class Hold(
-//    Assume every image is in ratio 3:4
-//    X should be a Float between 0 - 100
-//    Y as well
-//
-    val X: Float,
-    val Y: Float,
-    val Size: Float,
+    val X: Float, // between 0.0 and 1.0
+    val Y: Float, // between 0.0 and 1.0
+    val Size: Float, // to calculate absolute Size one has to multiply this value by frame max width
     val Shape: String,
     val Angle: Float,
 
@@ -23,7 +21,19 @@ data class Hold(
     val UpdatedAt: String? = null,
     val DeletedAt: String? = null,
     val WallID: UInt? = null
-) : Parcelable
+) : Parcelable {
+    fun getAbsoluteX(viewFrame: ViewFrame): Float {
+        return X * viewFrame.parentWidth
+    }
+
+    fun getAbsoluteY(viewFrame: ViewFrame): Float {
+        return Y * viewFrame.parentHeight
+    }
+
+    fun getAbsoluteSize(viewFrame: ViewFrame): Float {
+        return Size * viewFrame.parentWidth
+    }
+}
 
 enum class HoldType {
     WALL_HOLD, HOLD, START_HOLD, TOP_HOLD

--- a/app/src/main/java/com/example/wspinapp/utils/HoldDrawer.kt
+++ b/app/src/main/java/com/example/wspinapp/utils/HoldDrawer.kt
@@ -3,6 +3,7 @@ package com.example.wspinapp.utils
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.util.Log
 import androidx.core.content.ContextCompat
 import com.example.wspinapp.R
 import com.example.wspinapp.model.Hold
@@ -35,9 +36,13 @@ class HoldDrawer(context: Context, color: Int = R.color.yellow, alpha: Int = 255
         also all triangle, circle and rectangle drawers should implement an interface draw
      */
 
-    fun draw(hold: Hold, canvas: Canvas, scaleFactor: Float = 1f) {
+    fun draw(hold: Hold, canvas: Canvas) {
+        val cx = hold.X * canvas.width
+        val cy = hold.Y * canvas.height
+        val size = hold.Size * canvas.width
+
         assert(hold.Shape.lowercase() == HoldShape.CIRCLE.str) { hold.Shape } // for now we can only add circle but it will change in future
-        circleDrawer.drawCircle(canvas, hold.X, hold.Y, hold.Size * scaleFactor)
+        circleDrawer.drawCircle(canvas, cx, cy, size)
     }
 
     fun draw(state: HoldDrawingState, canvas: Canvas) {

--- a/app/src/main/java/com/example/wspinapp/utils/HoldPicker.kt
+++ b/app/src/main/java/com/example/wspinapp/utils/HoldPicker.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Canvas
 import android.view.MotionEvent
-import android.view.View
 import com.example.wspinapp.R
 import com.example.wspinapp.model.Hold
 import com.example.wspinapp.model.HoldType
@@ -21,21 +20,21 @@ class HoldPicker(context: Context) {
     private var touchX : Float = 0f
     private var touchY : Float = 0f
 
-    private fun getClickedHolds(): List<Hold> {
+    private fun getClickedHolds(frame: ViewFrame): List<Hold> {
         val clicked = mutableListOf<Hold>()
         for (circle in holds) {
-            if (pointInCircle(touchX, touchY, circle.key)) {
+            if (pointInCircle(touchX, touchY, circle.key, frame)) {
                 clicked.add(circle.key)
             }
         }
         return clicked
     }
 
-    private fun pointInCircle(x: Float, y: Float, circle: Hold) : Boolean {
-        val distX = abs(circle.X - x)
-        val distY = abs(circle.Y - y)
+    private fun pointInCircle(x: Float, y: Float, circle: Hold, frame: ViewFrame) : Boolean {
+        val distX = abs(circle.getAbsoluteX(frame) - x)
+        val distY = abs(circle.getAbsoluteY(frame) - y)
 
-        return sqrt(distX * distX + distY * distY) <= circle.Size
+        return sqrt(distX * distX + distY * distY) <= circle.getAbsoluteSize(frame)
     }
 
 
@@ -47,7 +46,7 @@ class HoldPicker(context: Context) {
         touchY = event.y
 
         if (event.action == MotionEvent.ACTION_DOWN) {
-            val clickedHolds = getClickedHolds()
+            val clickedHolds = getClickedHolds(frame)
             clickedHolds.forEach { hold ->
                 when (holds[hold]) {
                     HoldType.WALL_HOLD -> holds[hold] = HoldType.HOLD

--- a/app/src/main/java/com/example/wspinapp/utils/ViewFrame.kt
+++ b/app/src/main/java/com/example/wspinapp/utils/ViewFrame.kt
@@ -11,12 +11,14 @@ class ViewFrame(
     var minY: Float,
     var maxX: Float,
     var maxY: Float,
-    var scaleFactor: Float
+    var scaleFactor: Float,
+    var parentWidth: Int,
+    var parentHeight: Int,
 ) {
     companion object {
         fun from(imageView: ImageView?): ViewFrame{
             if (imageView == null) {
-                return ViewFrame(0f, 0f, 0f, 0f, 0f)
+                return ViewFrame(0f, 0f, 0f, 0f, 0f, 1, 1)
             }
 
             val scaleFactor = imageView.scaleX // scaleY should be same
@@ -30,7 +32,9 @@ class ViewFrame(
                 maxX = l + width / scaleFactor,
                 minY = t,
                 maxY = t + height / scaleFactor,
-                scaleFactor = scaleFactor
+                scaleFactor = scaleFactor,
+                parentWidth = imageView.measuredWidth,
+                parentHeight = imageView.measuredHeight,
             )
         }
     }

--- a/app/src/main/res/layout/wall.xml
+++ b/app/src/main/res/layout/wall.xml
@@ -1,59 +1,105 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:onClick="unselectRoute">
+
+    <TextView
+        android:id="@+id/title"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:onClick="unselectRoute">
+        android:layout_height="wrap_content"
+        android:maxHeight="30dp"
+        android:text="A WALL"
+        app:layout_constraintBottom_toTopOf="@id/content"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <FrameLayout
-            android:layout_width="fill_parent"
-            android:layout_height="0dp"
-            app:layout_constraintDimensionRatio="3:4"
-            app:srcCompat="@drawable/ic_launcher"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/content"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintBottom_toTopOf="@id/routes_recycler_view"
+        app:layout_constraintVertical_weight="3"
+        >
+
+
+        <FrameLayout
             android:id="@+id/wall_image_frame"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-        <ImageView
-                android:layout_width="fill_parent"
-                android:layout_height="match_parent"
-                app:srcCompat="@drawable/ic_launcher"
-                android:id="@+id/wall_image" />
-
-        <com.example.wspinapp.HoldsOverlay
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:id="@+id/wall_holds_canvas" />
-
-    </FrameLayout>
-
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-            app:layout_constraintRight_toRightOf="parent"
-            android:layout_width="56dp"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            app:srcCompat="@android:drawable/ic_input_add"
-            android:id="@+id/add_route_fab"
-            app:backgroundTint="@color/sand_sunny"
-            app:rippleColor="@color/sand_shadowy"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginBottom="24dp"
-            android:onClick="addRoute"
-            android:layout_marginRight="24dp" />
-
-    <androidx.recyclerview.widget.RecyclerView
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@+id/wall_image_frame"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintDimensionRatio="3:4"
+            app:layout_constraintEnd_toStartOf="@id/toolbar"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="8dp"
-            android:id="@+id/routes_recycler_view"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            android:clipChildren="true"
-            android:clipToPadding="true"
-            android:scrollbars="vertical" />
+            app:layout_constraintHorizontal_weight="1"
+            app:srcCompat="@drawable/ic_launcher">
+
+            <ImageView
+                android:id="@+id/wall_image"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:srcCompat="@drawable/ic_launcher" />
+
+            <com.example.wspinapp.HoldsOverlay
+                android:id="@+id/wall_holds_canvas"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </FrameLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/toolbar"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            app:layout_constraintStart_toEndOf="@id/wall_image_frame"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_weight="1"
+            >
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/top_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/search_filters"
+                >
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/add_route_fab"
+                    android:layout_width="56dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginRight="24dp"
+                    android:layout_marginBottom="24dp"
+                    android:clickable="true"
+                    android:onClick="addRoute"
+                    app:backgroundTint="@color/sand_sunny"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:rippleColor="@color/sand_shadowy"
+                    app:srcCompat="@android:drawable/ic_input_add" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/search_filters"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toBottomOf="@id/top_toolbar"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/routes_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="4dp"
+        android:clipChildren="true"
+        android:clipToPadding="true"
+        android:scrollbars="vertical"
+        app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/content"
+        app:layout_constraintVertical_weight="2"
+        tools:layout_editor_absoluteX="4dp" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
According to figma.
Design itself is not that important but important thing that is being added here is that there might be wall (with holds) previews that are smaller than original one.
This means that X and Y from Holds cannot represent px od dp, but instead has to represent scale (that is value between 0.0 and 1.0) so that they can work for images that are of some other pixel values. (like 3x4 or 3000x4000).


This is draft for now because I figured I have to refactor all the imageDrawing logic to be more readable and understandable and also reusable. Currently it's very hard to understand what's going on there and how to modify it.